### PR TITLE
add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@ksakira10/ripplejs",
   "author": "Jacob Kelley",
   "version": "1.2.1",
+  "main": "dist/ripple.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/KsAkira10/Ripple.js.git"


### PR DESCRIPTION
Add "main" entry to package.json so that npm can find the entry point as well. Bower seems to be deprecated these days.